### PR TITLE
Use uid for the name of the user node instead of the munged email address

### DIFF
--- a/app/utils/firebaseUtils.js
+++ b/app/utils/firebaseUtils.js
@@ -3,16 +3,8 @@ var forge = ""; //YOUR FIREBASE URL HERE
 var ref = new Firebase(forge);
 var cachedUser = null;
 
-var formatEmailForFirebase =  function(email){
-  var key = email.replace('@', '^');
-  if(key.indexOf('.') !== -1){
-    return key.split('.').join('*');
-  }
-  return key;
-};
-
 var addNewUserToFB = function(newUser){
-  var key = formatEmailForFirebase(newUser.email);
+  var key = newUser.uid;
   ref.child('user').child(key).set(newUser);
 };
 


### PR DESCRIPTION
As a starter kit it's a little hard to get started because it's not obvious how to create the security rules for the top-level user "directory". 

The error is:
[Warning] FIREBASE WARNING: set at /user/fred^example*com failed: permission_denied  (bundle.js, line 9804)

Firebase recommends using uid as the name of this node, and gives examples on how to create security rules to authorize it. 

This PR changes the name to uid to conform with Firebase's documentation.

I'm sure you have a good reason for not using the uid, so another way to fix this would be to add a small note in the README giving an example of how to create security rules to get started using the munged-email-address method.
