### PR TITLE
Replace currentUser to email

### DIFF
--- a/app/utils/authenticated.js
+++ b/app/utils/authenticated.js
@@ -5,7 +5,7 @@ firebase.initializeApp(config);
 
 function requireAuth(nextState, replace) {
 
-    if(null === firebase.auth().currentUser) {
+    if(null === firebase.auth().email) {
         replace({
           pathname: '/login',
           state: { nextPathname: nextState.location.pathname }


### PR DESCRIPTION
I ran your example and it seems that Firebase is not returning currentUser when we use email/password auth (not Facebook or Twitter)
