### PR TITLE
Adds login/register errors, password reset

### DIFF
--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -1,10 +1,25 @@
 import React, { Component } from 'react'
-import { login } from '../helpers/auth'
+import { login, resetPassword } from '../helpers/auth'
+
+function setErrorMsg(error) {
+  return {
+    loginMessage: error
+  }
+}
 
 export default class Login extends Component {
+  state = { loginMessage: null }
   handleSubmit = (e) => {
     e.preventDefault()
     login(this.email.value, this.pw.value)
+      .catch((error) => {
+          this.setState(setErrorMsg('Invalid username/password.'))
+        })
+  }
+  resetPassword = () => {
+    resetPassword(this.email.value)
+      .then(() => this.setState(setErrorMsg(`Password reset email sent to ${this.email.value}.`)))
+      .catch((error) => this.setState(setErrorMsg(`Email address not found.`)))
   }
   render () {
     return (
@@ -19,6 +34,14 @@ export default class Login extends Component {
             <label>Password</label>
             <input type="password" className="form-control" placeholder="Password" ref={(pw) => this.pw = pw} />
           </div>
+          {
+            this.state.loginMessage &&
+            <div className="alert alert-danger" role="alert">
+              <span className="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+              <span className="sr-only">Error:</span>
+              &nbsp;{this.state.loginMessage} <a href="#" onClick={this.resetPassword} className="alert-link">Forgot Password?</a>
+            </div>
+          }
           <button type="submit" className="btn btn-primary">Login</button>
         </form>
       </div>

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -1,10 +1,18 @@
 import React, { Component } from 'react'
 import { auth } from '../helpers/auth'
 
+function setErrorMsg(error) {
+  return {
+    registerError: error.message
+  }
+}
+
 export default class Register extends Component {
+  state = { registerError: null }
   handleSubmit = (e) => {
     e.preventDefault()
     auth(this.email.value, this.pw.value)
+      .catch(e => this.setState(setErrorMsg(e)))
   }
   render () {
     return (
@@ -19,6 +27,14 @@ export default class Register extends Component {
             <label>Password</label>
             <input type="password" className="form-control" placeholder="Password" ref={(pw) => this.pw = pw} />
           </div>
+          {
+            this.state.registerError &&
+            <div className="alert alert-danger" role="alert">
+              <span className="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
+              <span className="sr-only">Error:</span>
+              &nbsp;{this.state.registerError}
+            </div>
+          }
           <button type="submit" className="btn btn-primary">Register</button>
         </form>
       </div>

--- a/src/helpers/auth.js
+++ b/src/helpers/auth.js
@@ -3,7 +3,6 @@ import { ref, firebaseAuth } from '../config/constants'
 export function auth (email, pw) {
   return firebaseAuth().createUserWithEmailAndPassword(email, pw)
     .then(saveUser)
-    .catch((error) => console.log('Oops', error))
 }
 
 export function logout () {
@@ -12,6 +11,10 @@ export function logout () {
 
 export function login (email, pw) {
   return firebaseAuth().signInWithEmailAndPassword(email, pw)
+}
+
+export function resetPassword (email) {
+  return firebaseAuth().sendPasswordResetEmail(email)
 }
 
 export function saveUser (user) {


### PR DESCRIPTION
Thanks for putting together this repo. It's awesome 🥇!

This PR:
- Adds user facing registering/login errors.
- Adds "forgot password?" link, which sends password reset email.

Thoughts:
This PR could be more elegant/abstracted, but I wanted to make minimal changes to get this functionality. 

The login screen will just tell the user that their username/pass is invalid, whereas the register screen will tell them specifically what's wrong. I left off specific error messages on login screens because it can be easier for people to hack an account with those error messages. 

Also, it blew my mind away how easy Firebase makes adding user accounts and sending password reset emails. 

Again, thanks for the awesome repo!