### PR TITLE
Adding docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:8-alpine as builder
+
+WORKDIR /code/
+
+EXPOSE 3000
+
+COPY . .
+
+RUN npm install
+
+ENTRYPOINT npm run start

--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -1,0 +1,18 @@
+FROM node:8-alpine as builder
+
+WORKDIR /code/
+
+EXPOSE 3000
+
+COPY . .
+
+RUN npm install --unsafe-perm
+
+RUN npm run build
+
+
+FROM nginx
+
+WORKDIR /usr/share/nginx/html
+
+COPY --from=builder /code/build .

--- a/README.md
+++ b/README.md
@@ -20,5 +20,5 @@ For more info, visit [Protected routes and authentication with React Router v4](
 
 #### Try it out in a [Docker](https://www.docker.com/) container:
 * Run a container running the prod version: `docker run -p 8080:80 -d allthethings/react-router-firebase-auth`
-* Or build a dev version, locally: `docker build -t react-router-firebase-auth .`
+* **Or** build a dev version, locally: `docker build -t react-router-firebase-auth .`
 * Then run the image (listens for changes to src): `docker run -v "$(pwd)/src:/code/src" -p 3000:3000 -d --name react-router-firebase-auth react-router-firebase-auth`

--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ For more info, visit [Protected routes and authentication with React Router v4](
 * ```npm install```
 * ```npm start```
 * Visit ```localhost:3000```
+
+#### Try it out in a [Docker](https://www.docker.com/) container:
+* Run a container running the prod version: `docker run -p 8080:80 -d allthethings/react-router-firebase-auth`
+* Or build a dev version, locally: `docker build -t react-router-firebase-auth .`
+* Then run the image (listens for changes to src): `docker run -v "$(pwd)/src:/code/src" -p 3000:3000 -d --name react-router-firebase-auth react-router-firebase-auth`


### PR DESCRIPTION
- Adding docker image files for both prod and dev use
- Adding instructions to top level README.md to:
  - Run a copy of the prod version hosted on hub.docker to try out the project
  - Build and run an image that will listen to changes on the host machine (to allow developers to use an IDE on their host machine)